### PR TITLE
It fixes #39

### DIFF
--- a/ispyb-ejb/sql_scripts/mysql/update_scripts/2017_02_22_Bug_add_siteId.sql
+++ b/ispyb-ejb/sql_scripts/mysql/update_scripts/2017_02_22_Bug_add_siteId.sql
@@ -1,0 +1,7 @@
+USE `pydb`;
+
+insert into SchemaStatus (scriptName, schemaStatus) values ('2017_02_22_Bug_add_siteId.sql','ONGOING');
+
+ALTER TABLE Login ADD siteId varchar(45) NULL AFTER roles ;
+
+update SchemaStatus set schemaStatus = 'DONE' where scriptName = '2017_02_22_Bug_add_siteId.sql';


### PR DESCRIPTION
siteId column is missing in the Login table. 

siteId identifies a person and it is a value given by the user portal (SMIS, for instance). 

I'have added an SQL script that creates such field
