### PR TITLE
Fix incorrect dependency version for ispyb-ejb3

### DIFF
--- a/ispyb-bcr-ear/pom.xml
+++ b/ispyb-bcr-ear/pom.xml
@@ -15,7 +15,7 @@
 			<groupId>ispyb</groupId>
 			<artifactId>ispyb-ejb3</artifactId>
 			<type>ejb</type>
-			<version>5.3.4</version>
+			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/ispyb-bcr/pom.xml
+++ b/ispyb-bcr/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>ispyb</groupId>
 			<artifactId>ispyb-ejb3</artifactId>
-			<version>5.3.4</version>
+			<version>5.4.1</version>
 			<scope>provided</scope>
 		</dependency>
 


### PR DESCRIPTION
The version specified for the `ispyb-ejb3` dependency in `ispyb-bcr/pom.xml` and `ispyb-bcr-ear/pom.xml` is wrong.  This PR fixes that.

Without this fix, running `mvn clean install` fails with:

```
[ERROR] Failed to execute goal on project ispyb-bcr: Could not resolve dependencies for project ispyb:ispyb-bcr:war:5.0.3: Could not find artifact ispyb:ispyb-ejb3:jar:5.3.4 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
```

and, if the above is fixed, then with:

```
[ERROR] Failed to execute goal on project ispyb-bcr-ear: Could not resolve dependencies for project ispyb:ispyb-bcr-ear:ear:5.4.1: Failure to find ispyb:ispyb-ejb3:jar:5.3.4 in https://repository.jboss.org/nexus/content/groups/public/ was cached in the local repository, resolution will not be reattempted until the update interval of JBoss Repository has elapsed or updates are forced -> [Help 1]
```

Note that this PR makes `ispyb-bcr-ear/pom.xml` use `${project.version}` for the `ispyb-ejb3` dependency version, but it does not do the same for `ispyb-bcr/pom.xml` (which has a hard coded version instead) because it does not have `ispyb-parent` as its parent.  All the modules have `ispyb-parent` as their parent except for `ispyb-bcr`; is that intentional?