### PR TITLE
Remove bogus <url> element from ispyb-ui project

### DIFF
--- a/ispyb-ui/pom.xml
+++ b/ispyb-ui/pom.xml
@@ -9,7 +9,6 @@
 	
 	<artifactId>ispyb-ui</artifactId>
 	<packaging>war</packaging>
-	<url>http://maven.apache.org</url>
 	
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
The `<url>` element in a Maven `<project>` element is for the project's home page.  The `<url>` element of the `ispyb-ui` project was set to `http://maven.apache.org` which is not the home page of the `ispyb-ui` project, so just remove it.