### PR TITLE
Make it easier to build and run ISPyB out of the box

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Dispyb.env=development

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,2 @@
 -Dispyb.env=development
+-Dispyb.site=GENERIC

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mvn install:install-file -Dfile=dependencies/securityfilter.jar -DgroupId=se
     mvn install:install-file -Dfile=dependencies/jhdfobj.jar -DgroupId=jhdfobj -DartifactId=jhdfobj -Dversion=1.0 -Dpackaging=jar && \
     mvn install:install-file -Dfile=dependencies/ispyb-userportal-gen-1.5.jar -DgroupId=ispyb -DartifactId=ispyb-userportal-gen -Dversion=1.5 -Dpackaging=jar && \
     mvn install:install-file -Dfile=dependencies/Struts-Layout-1.2.jar -DgroupId=struts-layout -DartifactId=struts-layout -Dversion=1.2 -Dpackaging=jar && \
-    mvn install -P ispyb.site-MAXIV,ispyb.env-PROD && \
+    mvn install -P ispyb.site-MAXIV,ispyb.env-production && \
     cp ispyb-ear/target/ispyb.ear /var/ispyb.ear
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mvn install:install-file -Dfile=dependencies/securityfilter.jar -DgroupId=se
     mvn install:install-file -Dfile=dependencies/jhdfobj.jar -DgroupId=jhdfobj -DartifactId=jhdfobj -Dversion=1.0 -Dpackaging=jar && \
     mvn install:install-file -Dfile=dependencies/ispyb-userportal-gen-1.5.jar -DgroupId=ispyb -DartifactId=ispyb-userportal-gen -Dversion=1.5 -Dpackaging=jar && \
     mvn install:install-file -Dfile=dependencies/Struts-Layout-1.2.jar -DgroupId=struts-layout -DartifactId=struts-layout -Dversion=1.2 -Dpackaging=jar && \
-    mvn install -P ispyb.site-MAXIV,ispyb.env-production && \
+    mvn install -Dispyb.site=MAXIV -Dispyb.env=production && \
     cp ispyb-ear/target/ispyb.ear /var/ispyb.ear
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mvn install:install-file -Dfile=dependencies/securityfilter.jar -DgroupId=se
     mvn install:install-file -Dfile=dependencies/jhdfobj.jar -DgroupId=jhdfobj -DartifactId=jhdfobj -Dversion=1.0 -Dpackaging=jar && \
     mvn install:install-file -Dfile=dependencies/ispyb-userportal-gen-1.5.jar -DgroupId=ispyb -DartifactId=ispyb-userportal-gen -Dversion=1.5 -Dpackaging=jar && \
     mvn install:install-file -Dfile=dependencies/Struts-Layout-1.2.jar -DgroupId=struts-layout -DartifactId=struts-layout -Dversion=1.2 -Dpackaging=jar && \
-    mvn install -P MAXIV,PROD && \
+    mvn install -P ispyb.site-MAXIV,ispyb.env-PROD && \
     cp ispyb-ear/target/ispyb.ear /var/ispyb.ear
 
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ For example:
 		<profile>
 			<id>ispyb.site-ESRF</id>
 			<properties>
-				<ispyb.site>ESRF</ispyb.site>
 				<smis.ws.usr>******</smis.ws.usr>
 				<smis.ws.pwd>******</smis.ws.pwd>
 				<jboss.home>/opt/wildfly</jboss.home>

--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ For example:
 			</properties>
 		</profile>
 	</profiles>
-	<activeProfiles>
-		<activeProfile>ispyb.site-ESRF</activeProfile>
-	</activeProfiles>
 </settings>
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For example:
 	</proxies>
 	<profiles>
 		<profile>
-			<id>ESRF</id>
+			<id>ispyb.site-ESRF</id>
 			<properties>
 				<ispyb.site>ESRF</ispyb.site>
 				<smis.ws.usr>******</smis.ws.usr>
@@ -57,7 +57,7 @@ For example:
 		</profile>
 	</profiles>
 	<activeProfiles>
-		<activeProfile>ESRF</activeProfile>
+		<activeProfile>ispyb.site-ESRF</activeProfile>
 	</activeProfiles>
 </settings>
 ```

--- a/configuration/settings.xml
+++ b/configuration/settings.xml
@@ -220,7 +220,7 @@ under the License.
     -->
 	
 	<profile>
-      <id>GENERIC</id>
+      <id>ispyb.site-GENERIC</id>
 		<properties>
 			<ispyb.site>GENERIC</ispyb.site>
 			<smis.ws.usr>xxx</smis.ws.usr>
@@ -242,7 +242,7 @@ under the License.
     </properties>
   </profile>
   <profile>
-    <id>MAXIV</id>
+    <id>ispyb.site-MAXIV</id>
     <properties>
         <ispyb.site>MAXIV</ispyb.site>
     </properties>
@@ -252,7 +252,7 @@ under the License.
 	<!--
 	<profile>	
 
-		<id>ESRF</id>
+		<id>ispyb.site-ESRF</id>
 		<properties>
 			<ispyb.site>ESRFsettings</ispyb.site>
 		</properties>
@@ -260,7 +260,7 @@ under the License.
 	
 	<profile>	
 		
-		<id>EMBL</id>
+		<id>ispyb.site-EMBL</id>
 		<properties>
 			<ispyb.site>EMBL</ispyb.site>
 		</properties>
@@ -307,7 +307,7 @@ under the License.
    | List of profiles that are active for all builds.
    |   -->
   <activeProfiles>
-    <activeProfile>ESRF</activeProfile>
+    <activeProfile>ispyb.site-ESRF</activeProfile>
   </activeProfiles>
 
 </settings>

--- a/configuration/settings.xml
+++ b/configuration/settings.xml
@@ -254,7 +254,7 @@ under the License.
 
 		<id>ispyb.site-ESRF</id>
 		<properties>
-			<ispyb.site>ESRFsettings</ispyb.site>
+			<ispyb.site>ESRF</ispyb.site>
 		</properties>
     </profile>
 	

--- a/configuration/settings.xml
+++ b/configuration/settings.xml
@@ -220,9 +220,9 @@ under the License.
     -->
 	
 	<profile>
-      <id>NEWSITE</id>
+      <id>GENERIC</id>
 		<properties>
-			<ispyb.site>NEWSITE</ispyb.site>
+			<ispyb.site>GENERIC</ispyb.site>
 			<smis.ws.usr>xxx</smis.ws.usr>
 			<smis.ws.pwd>******</smis.ws.pwd>
 			<ispyb.ws.usr>xxxxxx</ispyb.ws.usr>

--- a/configuration/settings.xml
+++ b/configuration/settings.xml
@@ -307,7 +307,14 @@ under the License.
    | List of profiles that are active for all builds.
    |   -->
   <activeProfiles>
-    <activeProfile>ispyb.site-ESRF</activeProfile>
+    <!--
+     | Activate the user-jdcasey profile.
+    <activeProfile>user-jdcasey</activeProfile>
+    -->
+    <!--
+     | Activate the user-brett profile.
+    <activeProfile>user-brett</activeProfile>
+    -->
   </activeProfiles>
 
 </settings>

--- a/configuration/settings.xml
+++ b/configuration/settings.xml
@@ -222,7 +222,6 @@ under the License.
 	<profile>
       <id>ispyb.site-GENERIC</id>
 		<properties>
-			<ispyb.site>GENERIC</ispyb.site>
 			<smis.ws.usr>xxx</smis.ws.usr>
 			<smis.ws.pwd>******</smis.ws.pwd>
 			<ispyb.ws.usr>xxxxxx</ispyb.ws.usr>
@@ -244,7 +243,6 @@ under the License.
   <profile>
     <id>ispyb.site-MAXIV</id>
     <properties>
-        <ispyb.site>MAXIV</ispyb.site>
     </properties>
   </profile>
   -->
@@ -254,7 +252,6 @@ under the License.
 
 		<id>ispyb.site-ESRF</id>
 		<properties>
-			<ispyb.site>ESRF</ispyb.site>
 		</properties>
     </profile>
 	
@@ -262,7 +259,6 @@ under the License.
 		
 		<id>ispyb.site-EMBL</id>
 		<properties>
-			<ispyb.site>EMBL</ispyb.site>
 		</properties>
     </profile>
 

--- a/documentation/ISPyB_DevelopersGuide.md
+++ b/documentation/ISPyB_DevelopersGuide.md
@@ -271,7 +271,7 @@ the database update (WSClient).
 
 ## Using Maven
 
-### Install maven 3.1.1
+### Install maven 3.3.1
 
 RFC: `ispyb.site` is already on `pom.xml` and could be moved to
 `ispyb-parent/pom.xml`.
@@ -338,14 +338,29 @@ location.
 
 ### Environment and Site Customization
 
-In the `pom.xml` of `ispyb-ui` and `ispyb-ejb` you will find profiles, there
-are for now 2 types of profiles:
+ISPyB is customized by its environment and site.
 
-  * Environment profiles
+There are three environments (previously known as deployment modes)
+for which ISPyB can be built and run: `production`, `development`, and
+`test`.  The default environment is `development`.  Each environment has
+a corresponding Maven profile named `ispyb.env-<environment>`, where
+`<environment>` is the name of the environment.  These profiles allow
+per-environment customization (e.g., JavaScript could be minified in the
+`production` environment, but not in the `development` environment).  The
+environment can be set via the `ispyb.env` system property; the allowed
+values are the environment names.  By default, `ispyb.env` is set to the
+name of the default environment: `development`.
 
-    `ispyb.env-development`, `ispyb.env-test`, and `ispyb.env-production`
-    define the way the application is deployed: for example with
-    `ispyb.env-development`, the javascript is not minimized.
+To change the environment for the user invoking Maven, add
+`-Dispyb.env=<environment>`, where `<environment>` is the name of the
+desired environment, to the `MAVEN_OPTS` environment variable.
+
+To change the environment for an invocation of Maven, add
+`-Dispyb.env=<environment>`, where `<environment>` is the name of
+the desired environment, to the Maven command line (e.g., `mvn
+-Dispyb.env=production clean install`).
+
+In the `pom.xml` of `ispyb-ui` and `ispyb-ejb`, you will find site profiles:
 
   * Site profiles (see [Profiles: site specific files and
     configuration](#profiles-site-specific-files-and-configuration))
@@ -739,7 +754,11 @@ private boolean validate(ViewShippingForm form, ActionErrors errors) {
 }
 ```
 
-## Profiles: site specific files and configuration
+## Profiles: environment- and site-specific files and configuration
+
+The environment profiles are defined in the `pom.xml` file of the `ispyb-ejb`
+module. Each environment profile contains all the properties for a specific
+environment.
 
 The site profile is defined in the `pom.xml` in `ispyb-ejb` module. The site
 profile contains all the properties linked to a specific profile. See the

--- a/documentation/ISPyB_DevelopersGuide.md
+++ b/documentation/ISPyB_DevelopersGuide.md
@@ -343,9 +343,9 @@ are for now 2 types of profiles:
 
   * Environment profiles
 
-    `ispyb.env-DEV`, `ispyb.env-ALT`, and `ispyb.env-PROD` define the way the
-    application is deployed: for example with `ispyb.env-DEV`, the javascript
-    is not minimized.
+    `ispyb.env-development`, `ispyb.env-test`, and `ispyb.env-production`
+    define the way the application is deployed: for example with
+    `ispyb.env-development`, the javascript is not minimized.
 
   * Site profiles (see [Profiles: site specific files and
     configuration](#profiles-site-specific-files-and-configuration))

--- a/documentation/ISPyB_DevelopersGuide.md
+++ b/documentation/ISPyB_DevelopersGuide.md
@@ -273,9 +273,6 @@ the database update (WSClient).
 
 ### Install maven 3.3.1
 
-RFC: `ispyb.site` is already on `pom.xml` and could be moved to
-`ispyb-parent/pom.xml`.
-
 Configure your own `settings.xml` (copy the one from `maven/conf` and update
 them for you).
 

--- a/documentation/ISPyB_DevelopersGuide.md
+++ b/documentation/ISPyB_DevelopersGuide.md
@@ -336,20 +336,22 @@ classes built from wsdl.
 Customize the `bindings.xml` file in `src/main/resources` to the correct wsdl
 location.
 
-### Site and deployment customization
+### Environment and Site Customization
 
 In the `pom.xml` of `ispyb-ui` and `ispyb-ejb` you will find profiles, there
 are for now 2 types of profiles:
 
-  * Deployment profiles
+  * Environment profiles
 
-    `DEV`, `ALT`, and `PROD` define the way the application is deployed: for
-    example with `DEV`, the javascript is not minimized.
+    `ispyb.env-DEV`, `ispyb.env-ALT`, and `ispyb.env-PROD` define the way the
+    application is deployed: for example with `ispyb.env-DEV`, the javascript
+    is not minimized.
 
-  * Site configuration profiles (see [Profiles: site specific files and
+  * Site profiles (see [Profiles: site specific files and
     configuration](#profiles-site-specific-files-and-configuration))
 
-    `ESRF`, `EMBL`, `SOLEIL`, `MAXIV` profiles contains the properties
+    `ispyb.site-ESRF`, `ispyb.site-EMBL`, `ispyb.site-SOLEIL`,
+    `ispyb.site-MAXIV` profiles contains the properties
     previously defined in the `ISPyB_XXX.properties`.
 
     These profiles with their properties are defined in the `ispyb-ejb/pom.xml`
@@ -760,7 +762,7 @@ like:
 <profiles>
   <!-- ... -->
   <profile>
-    <id>GENERIC</id>
+    <id>ispyb.site-GENERIC</id>
     <properties>
       <ispyb.site>GENERIC</ispyb.site>
       <jboss.home>C:/java/appServers/wildfly-8.2.0.Final</jboss.home>
@@ -769,7 +771,7 @@ like:
 </profiles>
 <!-- ... -->
 <activeProfiles>
-<activeProfile>GENERIC</activeProfile>
+<activeProfile>ispyb.site-GENERIC</activeProfile>
 </activeProfiles>
 <!-- ... -->
 ```

--- a/documentation/ISPyB_DevelopersGuide.md
+++ b/documentation/ISPyB_DevelopersGuide.md
@@ -784,7 +784,6 @@ site, in the user's `settings.xml` file:
   <profile>
     <id>ispyb.site-GENERIC</id>
     <properties>
-      <ispyb.site>GENERIC</ispyb.site>
       <jboss.home>C:/java/appServers/wildfly-8.2.0.Final</jboss.home>
     </properties>
   </profile>

--- a/documentation/ISPyB_DevelopersGuide.md
+++ b/documentation/ISPyB_DevelopersGuide.md
@@ -741,7 +741,7 @@ private boolean validate(ViewShippingForm form, ActionErrors errors) {
 
 The site profile is defined in the `pom.xml` in `ispyb-ejb` module. The site
 profile contains all the properties linked to a specific profile. See the
-example of the `NEWSITE` profile in the `pom.xml`.
+example of the `GENERIC` profile in the `pom.xml`.
 
 For example it defines the `ispyb.site` property which value will be loaded
 and used in the Constants class (`SITE_IS_ESRF()` or `SITE_IS_SOLEIL()`, or
@@ -760,16 +760,16 @@ like:
 <profiles>
   <!-- ... -->
   <profile>
-    <id>NEWSITE</id>
+    <id>GENERIC</id>
     <properties>
-      <ispyb.site>NEWSITE</ispyb.site>
+      <ispyb.site>GENERIC</ispyb.site>
       <jboss.home>C:/java/appServers/wildfly-8.2.0.Final</jboss.home>
     </properties>
   </profile>
 </profiles>
 <!-- ... -->
 <activeProfiles>
-<activeProfile>NEWSITE</activeProfile>
+<activeProfile>GENERIC</activeProfile>
 </activeProfiles>
 <!-- ... -->
 ```

--- a/documentation/ISPyB_DevelopersGuide.md
+++ b/documentation/ISPyB_DevelopersGuide.md
@@ -360,21 +360,21 @@ To change the environment for an invocation of Maven, add
 the desired environment, to the Maven command line (e.g., `mvn
 -Dispyb.env=production clean install`).
 
-In the `pom.xml` of `ispyb-ui` and `ispyb-ejb`, you will find site profiles:
+There are five sites for customizing ISPyB: `ESRF`, `EMBL`, `SOLEIL`,
+`MAXIV`, and `GENERIC`.  The default site is `GENERIC`.  Each site has a
+corresponding Maven profile named `ispyb.site-<site>`, where `<site>` is
+the name of the site.  These profiles allow per-site customization (e.g.,
+the ISPyB root folder location).  The site can be set via the `ispyb.site`
+system property; the allowed values are the site names.  By default,
+`ispyb.site` is set to the name of the default site: `GENERIC`.
 
-  * Site profiles (see [Profiles: site specific files and
-    configuration](#profiles-site-specific-files-and-configuration))
+To change the site for the user invoking Maven, add `-Dispyb.site=<site>`,
+where `<site>` is the name of the desired site, to the `MAVEN_OPTS`
+environment variable.
 
-    `ispyb.site-ESRF`, `ispyb.site-EMBL`, `ispyb.site-SOLEIL`,
-    `ispyb.site-MAXIV` profiles contains the properties
-    previously defined in the `ISPyB_XXX.properties`.
-
-    These profiles with their properties are defined in the `ispyb-ejb/pom.xml`
-    only because the other modules are dependent on this one.
-
-    The profile is defined in the maven `settings.xml`
-    (see [Profiles: site specific files and
-    configuration](#profiles-site-specific-files-and-configuration)).
+To change the site for an invocation of Maven, add `-Dispyb.site=<site>`,
+where `<site>` is the name of the desired site, to the Maven command line
+(e.g., `mvn -Dispyb.site=ESRF clean install`).
 
 Properties:
 
@@ -773,8 +773,9 @@ module, and the correct values depend on the site where it is installed.
 The values of the `ISPyB.properties` are replaced by those in the `pom.xml`
 profile.
 
-You have to add in your maven `settings.xml` the active profile and its name
-like:
+To override site properties for the user running Maven, add properties to
+the `ispyb.site-<site>` profile, where `<site>` is the name of the desired
+site, in the user's `settings.xml` file:
 
 ```xml
 <!-- ... -->
@@ -788,10 +789,6 @@ like:
     </properties>
   </profile>
 </profiles>
-<!-- ... -->
-<activeProfiles>
-<activeProfile>ispyb.site-GENERIC</activeProfile>
-</activeProfiles>
 <!-- ... -->
 ```
 

--- a/documentation/settings.xml.example
+++ b/documentation/settings.xml.example
@@ -231,8 +231,6 @@ under the License.
 	<profile>
       <id>ispyb.site-ESRF</id>
 		<properties>
-			 <!-- RFC: ispyb.site is already on pom.xml and could be moved to ispyb-parent/pom.xml -->
-			 <!-- <ispyb.site>ESRF</ispyb.site> -->
 			<smis.ws.usr>ispyb</smis.ws.usr>
 			<smis.ws.pwd>******</smis.ws.pwd>
 			<jboss.home>C:/java/appServers/wildfly-8.2.0.Final</jboss.home>
@@ -245,7 +243,6 @@ under the License.
 
 		<id>ispyb.site-ESRF</id>
 		<properties>
-			<ispyb.site>ESRFsettings</ispyb.site>
 		</properties>
     </profile>
 	
@@ -253,7 +250,6 @@ under the License.
 		
 		<id>ispyb.site-EMBL</id>
 		<properties>
-			<ispyb.site>EMBL</ispyb.site>
 		</properties>
     </profile>
 

--- a/documentation/settings.xml.example
+++ b/documentation/settings.xml.example
@@ -298,7 +298,14 @@ under the License.
    | List of profiles that are active for all builds.
    |   -->
   <activeProfiles>
-    <activeProfile>ispyb.site-ESRF</activeProfile>
+    <!--
+     | Activate the user-jdcasey profile.
+    <activeProfile>user-jdcasey</activeProfile>
+    -->
+    <!--
+     | Activate the user-brett profile.
+    <activeProfile>user-brett</activeProfile>
+    -->
   </activeProfiles>
 
 </settings>

--- a/documentation/settings.xml.example
+++ b/documentation/settings.xml.example
@@ -229,7 +229,7 @@ under the License.
     -->
 	
 	<profile>
-      <id>ESRF</id>
+      <id>ispyb.site-ESRF</id>
 		<properties>
 			 <!-- RFC: ispyb.site is already on pom.xml and could be moved to ispyb-parent/pom.xml -->
 			 <!-- <ispyb.site>ESRF</ispyb.site> -->
@@ -243,7 +243,7 @@ under the License.
 	<!--
 	<profile>	
 
-		<id>ESRF</id>
+		<id>ispyb.site-ESRF</id>
 		<properties>
 			<ispyb.site>ESRFsettings</ispyb.site>
 		</properties>
@@ -251,7 +251,7 @@ under the License.
 	
 	<profile>	
 		
-		<id>EMBL</id>
+		<id>ispyb.site-EMBL</id>
 		<properties>
 			<ispyb.site>EMBL</ispyb.site>
 		</properties>
@@ -298,7 +298,7 @@ under the License.
    | List of profiles that are active for all builds.
    |   -->
   <activeProfiles>
-    <activeProfile>ESRF</activeProfile>
+    <activeProfile>ispyb.site-ESRF</activeProfile>
   </activeProfiles>
 
 </settings>

--- a/ispyb-bcr/pom.xml
+++ b/ispyb-bcr/pom.xml
@@ -326,18 +326,4 @@
 
 </plugins>
 	</build>
-	
-		<profiles>
-		<!-- profiles to separate site dependent properties -->
-		<profile>
-			<id>ispyb.site-ESRF</id>
-			<activation>
-				<property>
-					<name>ispyb.site</name>
-					<value>ESRF</value>
-				</property>
-			</activation>
-		</profile>
-	</profiles>
-	  
 </project>

--- a/ispyb-bcr/pom.xml
+++ b/ispyb-bcr/pom.xml
@@ -336,7 +336,6 @@
 					<name>ispyb.site</name>
 					<value>ESRF</value>
 				</property>
-				<activeByDefault>true</activeByDefault>
 			</activation>
 
 			<properties>

--- a/ispyb-bcr/pom.xml
+++ b/ispyb-bcr/pom.xml
@@ -332,6 +332,10 @@
 		<profile>
 			<id>ispyb.site-ESRF</id>
 			<activation>
+				<property>
+					<name>ispyb.site</name>
+					<value>ESRF</value>
+				</property>
 				<activeByDefault>true</activeByDefault>
 			</activation>
 

--- a/ispyb-bcr/pom.xml
+++ b/ispyb-bcr/pom.xml
@@ -337,10 +337,6 @@
 					<value>ESRF</value>
 				</property>
 			</activation>
-
-			<properties>
-				<ispyb.site>ESRF</ispyb.site>
-			</properties>
 		</profile>
 	</profiles>
 	  

--- a/ispyb-bcr/pom.xml
+++ b/ispyb-bcr/pom.xml
@@ -330,7 +330,7 @@
 		<profiles>
 		<!-- profiles to separate site dependent properties -->
 		<profile>
-			<id>ESRF</id>
+			<id>ispyb.site-ESRF</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>

--- a/ispyb-ear/pom.xml
+++ b/ispyb-ear/pom.xml
@@ -93,6 +93,12 @@
 	<profiles>
 		<profile>
 			<id>ispyb.site-SOLEIL</id>
+			<activation>
+				<property>
+					<name>ispyb.site</name>
+					<value>SOLEIL</value>
+				</property>
+			</activation>
 			<!-- Add dependencies and MANIFEST to declare in Class-Path the .jar needed by securityfilter to solve classloading issue -->
 			<dependencies>
 				<dependency>

--- a/ispyb-ear/pom.xml
+++ b/ispyb-ear/pom.xml
@@ -92,7 +92,7 @@
 	
 	<profiles>
 		<profile>
-			<id>SOLEIL</id>
+			<id>ispyb.site-SOLEIL</id>
 			<!-- Add dependencies and MANIFEST to declare in Class-Path the .jar needed by securityfilter to solve classloading issue -->
 			<dependencies>
 				<dependency>

--- a/ispyb-ejb/pom.xml
+++ b/ispyb-ejb/pom.xml
@@ -204,27 +204,27 @@
 		
 	</dependencies>
 	
-	  <!--  profiles to separate dev to prod properties -->
-  <!--  the dev properties have to be set according to your own dev environment -->
+	  <!--  profiles to separate development to production properties -->
+  <!--  the development properties have to be set according to your own development environment -->
   <profiles>
     <profile>
-  		<id>ispyb.env-PROD</id>
+  		<id>ispyb.env-production</id>
   		<activation>
         	<activeByDefault>true</activeByDefault>
       	</activation>
   		
   		<properties>
-  		  	<ispyb.env>PROD</ispyb.env>  		
+  		  	<ispyb.env>production</ispyb.env>  		
   			<js.minimized>true</js.minimized>
   			<js.alternative.path.enabled>false</js.alternative.path.enabled>
   			<js.alternative.path> </js.alternative.path>
   		</properties>
   	</profile>
      <profile>
-  		<id>ispyb.env-DEV</id>
+  		<id>ispyb.env-development</id>
   		<properties>
   			<js.minimized>false</js.minimized>
-  			<ispyb.env>DEV</ispyb.env>
+  			<ispyb.env>development</ispyb.env>
   			<js.alternative.path>http://172.26.4.24:8082</js.alternative.path>
   			<js.alternative.path.enabled>true</js.alternative.path.enabled>
   			<data.path>/work/ademaria/data/pyarch/</data.path>
@@ -350,7 +350,7 @@
   	<profile>
   		<id>ispyb.site-SOLEIL</id>
   		<properties>
-				<ispyb.env>PROD</ispyb.env>
+				<ispyb.env>production</ispyb.env>
 				<js.minimized>true</js.minimized>
 				<js.alternative.path></js.alternative.path>
 				<js.alternative.path.enabled>false</js.alternative.path.enabled>

--- a/ispyb-ejb/pom.xml
+++ b/ispyb-ejb/pom.xml
@@ -217,7 +217,6 @@
       	</activation>
   		
   		<properties>
-  		  	<ispyb.env>production</ispyb.env>  		
   			<js.minimized>true</js.minimized>
   			<js.alternative.path.enabled>false</js.alternative.path.enabled>
   			<js.alternative.path> </js.alternative.path>
@@ -233,7 +232,6 @@
 		</activation>
   		<properties>
   			<js.minimized>false</js.minimized>
-  			<ispyb.env>development</ispyb.env>
   			<js.alternative.path>http://172.26.4.24:8082</js.alternative.path>
   			<js.alternative.path.enabled>true</js.alternative.path.enabled>
   			<data.path>/work/ademaria/data/pyarch/</data.path>
@@ -386,7 +384,6 @@
 			</property>
 		</activation>
   		<properties>
-				<ispyb.env>production</ispyb.env>
 				<js.minimized>true</js.minimized>
 				<js.alternative.path></js.alternative.path>
 				<js.alternative.path.enabled>false</js.alternative.path.enabled>

--- a/ispyb-ejb/pom.xml
+++ b/ispyb-ejb/pom.xml
@@ -204,8 +204,7 @@
 		
 	</dependencies>
 	
-	  <!--  profiles to separate development to production properties -->
-  <!--  the development properties have to be set according to your own development environment -->
+	  <!--  profiles to separate environment properties -->
   <profiles>
     <profile>
   		<id>ispyb.env-production</id>
@@ -237,15 +236,6 @@
   			<data.path>/work/ademaria/data/pyarch/</data.path>
   		</properties>
   	</profile>
-	<profile>
-		<id>ispyb.env-test</id>
-		<activation>
-			<property>
-				<name>ispyb.env</name>
-				<value>test</value>
-			</property>
-		</activation>
-	</profile>
 
   <!--  profiles to separate site dependent properties -->  
   	<profile>

--- a/ispyb-ejb/pom.xml
+++ b/ispyb-ejb/pom.xml
@@ -208,7 +208,7 @@
   <!--  the dev properties have to be set according to your own dev environment -->
   <profiles>
     <profile>
-  		<id>PROD</id>
+  		<id>ispyb.env-PROD</id>
   		<activation>
         	<activeByDefault>true</activeByDefault>
       	</activation>
@@ -221,7 +221,7 @@
   		</properties>
   	</profile>
      <profile>
-  		<id>DEV</id>
+  		<id>ispyb.env-DEV</id>
   		<properties>
   			<js.minimized>false</js.minimized>
   			<ispyb.env>DEV</ispyb.env>
@@ -233,7 +233,7 @@
 
   <!--  profiles to separate site dependent properties -->  
   	<profile>
-  		<id>ESRF</id>
+  		<id>ispyb.site-ESRF</id>
   		
   		<properties>
   			<ispyb.site>ESRF</ispyb.site>
@@ -294,7 +294,7 @@
 		</properties>
   	</profile>
   	<profile>
-  		<id>EMBL</id>
+  		<id>ispyb.site-EMBL</id>
   		<properties>
  			<ispyb.site>EMBL</ispyb.site>
                         <ispyb.dbDialect>MYSQL</ispyb.dbDialect>
@@ -348,7 +348,7 @@
 		</properties>
   	</profile>
   	<profile>
-  		<id>SOLEIL</id>
+  		<id>ispyb.site-SOLEIL</id>
   		<properties>
 				<ispyb.env>PROD</ispyb.env>
 				<js.minimized>true</js.minimized>
@@ -417,7 +417,7 @@
   	</profile> 
   	
   	<profile>
-  		<id>MAXIV</id>  		
+  		<id>ispyb.site-MAXIV</id>  		
   		<properties>
   			<ispyb.site>MAXIV</ispyb.site>
   			<ispyb.dbDialect>MYSQL</ispyb.dbDialect>
@@ -484,7 +484,7 @@
   	</profile>
   	
   	<profile>
-  		<id>GENERIC</id>
+  		<id>ispyb.site-GENERIC</id>
   		
   		<properties>
   			<ispyb.site>GENERIC</ispyb.site>

--- a/ispyb-ejb/pom.xml
+++ b/ispyb-ejb/pom.xml
@@ -258,7 +258,6 @@
 		</activation>
   		
   		<properties>
-  			<ispyb.site>ESRF</ispyb.site>
   			<ispyb.dbDialect>MYSQL</ispyb.dbDialect>
   			<ispyb.dbJndiName.direct>java:jboss/ispyb_db_direct</ispyb.dbJndiName.direct>
   			<ispyb.authentication.method>LDAP</ispyb.authentication.method>
@@ -324,7 +323,6 @@
 			</property>
 		</activation>
   		<properties>
- 			<ispyb.site>EMBL</ispyb.site>
                         <ispyb.dbDialect>MYSQL</ispyb.dbDialect>
                         <ispyb.dbJndiName.direct>java:jboss/ispyb_db_direct</ispyb.dbJndiName.direct>
                         <ispyb.authentication.method>LDAP</ispyb.authentication.method>
@@ -388,7 +386,6 @@
 				<js.alternative.path></js.alternative.path>
 				<js.alternative.path.enabled>false</js.alternative.path.enabled>
 				
-				<ispyb.site>SOLEIL</ispyb.site>
 				<ispyb.dbDialect>MYSQL</ispyb.dbDialect>
 				<ispyb.dbJndiName>java:/mysql/ispyb_db</ispyb.dbJndiName>
 				<ispyb.dbJndiName.direct>java:jboss/ispyb_db_direct</ispyb.dbJndiName.direct>
@@ -458,7 +455,6 @@
 			</property>
 		</activation>
   		<properties>
-  			<ispyb.site>MAXIV</ispyb.site>
   			<ispyb.dbDialect>MYSQL</ispyb.dbDialect>
   			<ispyb.dbJndiName.direct>java:jboss/ispyb_db_direct</ispyb.dbJndiName.direct>
   			<ispyb.authentication.method>LDAP</ispyb.authentication.method>
@@ -532,8 +528,6 @@
 		</activation>
   		
   		<properties>
-  			<ispyb.site>GENERIC</ispyb.site>
-  			
   			<ispyb.dbDialect>MYSQL</ispyb.dbDialect>
   			<ispyb.dbJndiName.direct>java:jboss/ispyb_db_direct</ispyb.dbJndiName.direct>
   			<ispyb.authentication.method>SIMPLE</ispyb.authentication.method>

--- a/ispyb-ejb/pom.xml
+++ b/ispyb-ejb/pom.xml
@@ -214,7 +214,7 @@
       	</activation>
   		
   		<properties>
-  		  	<ispyb.deployment.mode>PROD</ispyb.deployment.mode>  		
+  		  	<ispyb.env>PROD</ispyb.env>  		
   			<js.minimized>true</js.minimized>
   			<js.alternative.path.enabled>false</js.alternative.path.enabled>
   			<js.alternative.path> </js.alternative.path>
@@ -224,7 +224,7 @@
   		<id>DEV</id>
   		<properties>
   			<js.minimized>false</js.minimized>
-  			<ispyb.deployment.mode>DEV</ispyb.deployment.mode>
+  			<ispyb.env>DEV</ispyb.env>
   			<js.alternative.path>http://172.26.4.24:8082</js.alternative.path>
   			<js.alternative.path.enabled>true</js.alternative.path.enabled>
   			<data.path>/work/ademaria/data/pyarch/</data.path>
@@ -350,7 +350,7 @@
   	<profile>
   		<id>SOLEIL</id>
   		<properties>
-				<ispyb.deployment.mode>PROD</ispyb.deployment.mode>
+				<ispyb.env>PROD</ispyb.env>
 				<js.minimized>true</js.minimized>
 				<js.alternative.path></js.alternative.path>
 				<js.alternative.path.enabled>false</js.alternative.path.enabled>

--- a/ispyb-ejb/pom.xml
+++ b/ispyb-ejb/pom.xml
@@ -523,38 +523,38 @@
   			<ispyb.authentication.method>SIMPLE</ispyb.authentication.method>
   			<ispyb.authorisation.proposals.source>database</ispyb.authorisation.proposals.source>
   			  			
-  			<ispyb.root.folder>/data/pyarch/</ispyb.root.folder>
-  			<ispyb.uploaded.root.folder>/data/pyarch/pdb/</ispyb.uploaded.root.folder>
+  			<ispyb.root.folder>${java.io.tmpdir}/${user.name}/ispyb/</ispyb.root.folder>
+  			<ispyb.uploaded.root.folder>${ispyb.root.folder}upload/</ispyb.uploaded.root.folder>
   			
-  			<ispyb.server.name.prod>wwws.esrf.fr</ispyb.server.name.prod>
-  			<ispyb.server.name.prod.alias>ispyb.esrf.fr</ispyb.server.name.prod.alias>
-  			<ispyb.server.name.prod.ext>160.103.210.124</ispyb.server.name.prod.ext>
-  			<ispyb.server.name.test>ispyvalid.esrf.fr</ispyb.server.name.test>
+  			<ispyb.server.name.prod>localhost</ispyb.server.name.prod>
+  			<ispyb.server.name.prod.alias>localhost</ispyb.server.name.prod.alias>
+  			<ispyb.server.name.prod.ext>127.0.0.1</ispyb.server.name.prod.ext>
+  			<ispyb.server.name.test>localhost</ispyb.server.name.test>
   			
   			<shipping.container.capacity>16</shipping.container.capacity>
 			<samplechanger.container.capacity>16</samplechanger.container.capacity>
 			<samplechanger.locations>5</samplechanger.locations>
 				
   			<ispyb.dataprocessing.denzo>true</ispyb.dataprocessing.denzo>
-  			<ispyb.path.mappingstyle>ESRF</ispyb.path.mappingstyle>
+  			<ispyb.path.mappingstyle>GENERIC</ispyb.path.mappingstyle>
   			<ispyb.bcm>mxcube</ispyb.bcm>
   			
-  			<mail.smtp.host>smtp.esrf.fr</mail.smtp.host>
-  			<mail.admin>solange.delageniere@esrf.fr</mail.admin>
-  			<mail.dev>solange.delageniere@esrf.fr</mail.dev>
-  			<mail.ispyb>ispyb@esrf.fr</mail.ispyb>
-  			<mail.stores>dewar-stores@esrf.fr</mail.stores>
+  			<mail.smtp.host>localhost</mail.smtp.host>
+  			<mail.admin>${user.name}@localhost</mail.admin>
+  			<mail.dev>${user.name}@localhost</mail.dev>
+  			<mail.ispyb>${user.name}@localhost</mail.ispyb>
+  			<mail.stores>${user.name}@localhost</mail.stores>
   			
-  			<mail.report.industry.from>mxind@esrf.fr</mail.report.industry.from>
-			<mail.report.industry.cc>ix@esrf.fr</mail.report.industry.cc>					
+  			<mail.report.industry.from>${user.name}@localhost</mail.report.industry.from>
+			<mail.report.industry.cc>${user.name}@localhost</mail.report.industry.cc>
 			
-			<dictionary.site>The ESRF</dictionary.site> 
+			<dictionary.site>GENERIC</dictionary.site>
 			<dictionary.bcm>mxCuBE</dictionary.bcm>
 			
 			<ispyb.authorisation.active>false</ispyb.authorisation.active>
 			
 			<ispyb.userportal.link>JSON</ispyb.userportal.link>
-			<ispyb.upload.folder.json>/data/pyarch/pdb/json/</ispyb.upload.folder.json>
+			<ispyb.upload.folder.json>${ispyb.uploaded.root.folder}json/</ispyb.upload.folder.json>
 
             <ispyb.shipping.reimburseddewars>false</ispyb.shipping.reimburseddewars>
 

--- a/ispyb-ejb/pom.xml
+++ b/ispyb-ejb/pom.xml
@@ -214,7 +214,6 @@
 				<name>ispyb.env</name>
 				<value>production</value>
 			</property>
-        	<activeByDefault>true</activeByDefault>
       	</activation>
   		
   		<properties>

--- a/ispyb-ejb/pom.xml
+++ b/ispyb-ejb/pom.xml
@@ -210,6 +210,10 @@
     <profile>
   		<id>ispyb.env-production</id>
   		<activation>
+			<property>
+				<name>ispyb.env</name>
+				<value>production</value>
+			</property>
         	<activeByDefault>true</activeByDefault>
       	</activation>
   		
@@ -222,6 +226,12 @@
   	</profile>
      <profile>
   		<id>ispyb.env-development</id>
+		<activation>
+			<property>
+				<name>ispyb.env</name>
+				<value>development</value>
+			</property>
+		</activation>
   		<properties>
   			<js.minimized>false</js.minimized>
   			<ispyb.env>development</ispyb.env>
@@ -230,10 +240,25 @@
   			<data.path>/work/ademaria/data/pyarch/</data.path>
   		</properties>
   	</profile>
+	<profile>
+		<id>ispyb.env-test</id>
+		<activation>
+			<property>
+				<name>ispyb.env</name>
+				<value>test</value>
+			</property>
+		</activation>
+	</profile>
 
   <!--  profiles to separate site dependent properties -->  
   	<profile>
   		<id>ispyb.site-ESRF</id>
+		<activation>
+			<property>
+				<name>ispyb.site</name>
+				<value>ESRF</value>
+			</property>
+		</activation>
   		
   		<properties>
   			<ispyb.site>ESRF</ispyb.site>
@@ -295,6 +320,12 @@
   	</profile>
   	<profile>
   		<id>ispyb.site-EMBL</id>
+		<activation>
+			<property>
+				<name>ispyb.site</name>
+				<value>EMBL</value>
+			</property>
+		</activation>
   		<properties>
  			<ispyb.site>EMBL</ispyb.site>
                         <ispyb.dbDialect>MYSQL</ispyb.dbDialect>
@@ -349,6 +380,12 @@
   	</profile>
   	<profile>
   		<id>ispyb.site-SOLEIL</id>
+		<activation>
+			<property>
+				<name>ispyb.site</name>
+				<value>SOLEIL</value>
+			</property>
+		</activation>
   		<properties>
 				<ispyb.env>production</ispyb.env>
 				<js.minimized>true</js.minimized>
@@ -418,6 +455,12 @@
   	
   	<profile>
   		<id>ispyb.site-MAXIV</id>  		
+		<activation>
+			<property>
+				<name>ispyb.site</name>
+				<value>MAXIV</value>
+			</property>
+		</activation>
   		<properties>
   			<ispyb.site>MAXIV</ispyb.site>
   			<ispyb.dbDialect>MYSQL</ispyb.dbDialect>
@@ -485,6 +528,12 @@
   	
   	<profile>
   		<id>ispyb.site-GENERIC</id>
+		<activation>
+			<property>
+				<name>ispyb.site</name>
+				<value>GENERIC</value>
+			</property>
+		</activation>
   		
   		<properties>
   			<ispyb.site>GENERIC</ispyb.site>

--- a/ispyb-ejb/pom.xml
+++ b/ispyb-ejb/pom.xml
@@ -484,10 +484,10 @@
   	</profile>
   	
   	<profile>
-  		<id>NEWSITE</id>
+  		<id>GENERIC</id>
   		
   		<properties>
-  			<ispyb.site>NEWSITE</ispyb.site>
+  			<ispyb.site>GENERIC</ispyb.site>
   			
   			<ispyb.dbDialect>MYSQL</ispyb.dbDialect>
   			<ispyb.dbJndiName.direct>java:jboss/ispyb_db_direct</ispyb.dbJndiName.direct>

--- a/ispyb-ejb/src/main/java/ispyb/common/util/Constants.java
+++ b/ispyb-ejb/src/main/java/ispyb/common/util/Constants.java
@@ -97,6 +97,8 @@ public final class Constants {
 
 	public static final String SITE_MAXIV = "MAXIV";
 
+	public static final String SITE_GENERIC = "GENERIC";
+
 	public static final boolean SITE_IS_ESRF() {
 		return getProperty(SITE_PROPERTY).equals(SITE_ESRF);
 	}
@@ -111,6 +113,10 @@ public final class Constants {
 
 	public static final boolean SITE_IS_SOLEIL() {
 		return getProperty(SITE_PROPERTY).equals(SITE_SOLEIL); // && DATABASE_IS_ORACLE(); //TODO
+	}
+
+	public static final boolean SITE_IS_GENERIC() {
+		return getProperty(SITE_PROPERTY).equals(SITE_GENERIC);
 	}
 
 	public static final SITE getSite() {

--- a/ispyb-ejb/src/main/resources/ISPyB.properties
+++ b/ispyb-ejb/src/main/resources/ISPyB.properties
@@ -18,8 +18,8 @@
 # Contributors : S. Delageniere, R. Leal, L. Launer, K. Levik, S. Veyrier, P. Brenchereau, M. Bodin
 #-------------------------------------------------------------------------------
 #
-# ===== ISPyB prod or dev properties =====
-# Values: PROD and DEV
+# ===== ISPyB Environment properties =====
+# Values: production, development, test
 ispyb.env=${ispyb.env}
 
 # javascript settings

--- a/ispyb-ejb/src/main/resources/ISPyB.properties
+++ b/ispyb-ejb/src/main/resources/ISPyB.properties
@@ -62,6 +62,13 @@ ldap.attribute  		= ${ldap.attribute}
 ldap.username  			= ${ldap.username}
 ldap.credential  		= ${ldap.credential}
 
+# RESTful web service property credentials store
+# Format: <credential>[;...]
+# Format of <credential>: <username>,<password>[,<role-list>]
+# Format of <role-list>: <role>[,...]
+# Example: alice,dragon,User,Manager;bob,batman,User
+ispyb.ws.rest.auth.property.credentials=${ispyb.ws.rest.auth.property.credentials}
+
 ISPyB.news.url					=http://www.esrf.fr/UsersAndScience/Experiments/MX/How_to_use_our_beamlines/ISPYB/ISPYBnews/
 ISPyB.help.url 					=http://www.esrf.fr/UsersAndScience/Experiments/MX/How_to_use_our_beamlines/ISPYB/ISPYBhelp/
 ISPyB.dewarTracking.url 		=http://www.esrf.fr/UsersAndScience/Experiments/MX/How_to_use_our_beamlines/ISPYB/ispyb-dewar-tracking

--- a/ispyb-ejb/src/main/resources/ISPyB.properties
+++ b/ispyb-ejb/src/main/resources/ISPyB.properties
@@ -20,7 +20,7 @@
 #
 # ===== ISPyB prod or dev properties =====
 # Values: PROD and DEV
-ispyb.deployment.mode=${ispyb.deployment.mode}
+ispyb.env=${ispyb.env}
 
 # javascript settings
 # in prod = true, in dev = false

--- a/ispyb-ui/pom.xml
+++ b/ispyb-ui/pom.xml
@@ -425,7 +425,6 @@
 					<name>ispyb.site</name>
 					<value>ESRF</value>
 				</property>
-				<activeByDefault>true</activeByDefault>
 			</activation>
 			
 			<properties>

--- a/ispyb-ui/pom.xml
+++ b/ispyb-ui/pom.xml
@@ -388,6 +388,10 @@
 		<profile>
 			<id>ispyb.env-production</id>
 			<activation>
+				<property>
+					<name>ispyb.env</name>
+					<value>production</value>
+				</property>
 				<activeByDefault>true</activeByDefault>
 			</activation>
 
@@ -400,6 +404,12 @@
 		
 		<profile>
 			<id>ispyb.env-development</id>
+			<activation>
+				<property>
+					<name>ispyb.env</name>
+					<value>development</value>
+				</property>
+			</activation>
 			<properties>
 				<js.minimized>false</js.minimized>
 				<ispyb.env>development</ispyb.env>
@@ -412,6 +422,10 @@
 		<profile>
 			<id>ispyb.site-ESRF</id>
 			<activation>
+				<property>
+					<name>ispyb.site</name>
+					<value>ESRF</value>
+				</property>
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			
@@ -425,10 +439,22 @@
 
 		<profile>
 			<id>ispyb.site-EMBL</id>
+			<activation>
+				<property>
+					<name>ispyb.site</name>
+					<value>EMBL</value>
+				</property>
+			</activation>
 		</profile>
 
 		<profile>
 			<id>ispyb.site-SOLEIL</id>
+			<activation>
+				<property>
+					<name>ispyb.site</name>
+					<value>SOLEIL</value>
+				</property>
+			</activation>
 
 			<build>
 				<plugins>
@@ -475,6 +501,12 @@
 
 		<profile>
 			<id>ispyb.site-MAXIV</id>
+			<activation>
+				<property>
+					<name>ispyb.site</name>
+					<value>MAXIV</value>
+				</property>
+			</activation>
 		</profile>
 
 	</profiles>

--- a/ispyb-ui/pom.xml
+++ b/ispyb-ui/pom.xml
@@ -381,28 +381,28 @@
 		</plugins>
 	</build>
 
-	<!-- profiles to separate dev to prod properties -->
-	<!-- the dev properties have to be set according to your own dev environment -->
+	<!-- profiles to separate development to production properties -->
+	<!-- the development properties have to be set according to your own development environment -->
 	<profiles>
 	
 		<profile>
-			<id>ispyb.env-PROD</id>
+			<id>ispyb.env-production</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
 
 			<properties>
-				<ispyb.env>PROD</ispyb.env>
+				<ispyb.env>production</ispyb.env>
 				<js.minimized>true</js.minimized>
 				<js.alternative.path.enabled>false</js.alternative.path.enabled>
 			</properties>
 		</profile>
 		
 		<profile>
-			<id>ispyb.env-DEV</id>
+			<id>ispyb.env-development</id>
 			<properties>
 				<js.minimized>false</js.minimized>
-				<ispyb.env>DEV</ispyb.env>
+				<ispyb.env>development</ispyb.env>
 				<js.alternative.path.enabled>true</js.alternative.path.enabled>				
 			</properties>
 		</profile>

--- a/ispyb-ui/pom.xml
+++ b/ispyb-ui/pom.xml
@@ -395,7 +395,6 @@
 			</activation>
 
 			<properties>
-				<ispyb.env>production</ispyb.env>
 				<js.minimized>true</js.minimized>
 				<js.alternative.path.enabled>false</js.alternative.path.enabled>
 			</properties>
@@ -411,7 +410,6 @@
 			</activation>
 			<properties>
 				<js.minimized>false</js.minimized>
-				<ispyb.env>development</ispyb.env>
 				<js.alternative.path.enabled>true</js.alternative.path.enabled>				
 			</properties>
 		</profile>

--- a/ispyb-ui/pom.xml
+++ b/ispyb-ui/pom.xml
@@ -392,7 +392,7 @@
 			</activation>
 
 			<properties>
-				<ispyb.deployment.mode>PROD</ispyb.deployment.mode>
+				<ispyb.env>PROD</ispyb.env>
 				<js.minimized>true</js.minimized>
 				<js.alternative.path.enabled>false</js.alternative.path.enabled>
 			</properties>
@@ -402,7 +402,7 @@
 			<id>DEV</id>
 			<properties>
 				<js.minimized>false</js.minimized>
-				<ispyb.deployment.mode>DEV</ispyb.deployment.mode>
+				<ispyb.env>DEV</ispyb.env>
 				<js.alternative.path.enabled>true</js.alternative.path.enabled>				
 			</properties>
 		</profile>

--- a/ispyb-ui/pom.xml
+++ b/ispyb-ui/pom.xml
@@ -386,7 +386,7 @@
 	<profiles>
 	
 		<profile>
-			<id>PROD</id>
+			<id>ispyb.env-PROD</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
@@ -399,7 +399,7 @@
 		</profile>
 		
 		<profile>
-			<id>DEV</id>
+			<id>ispyb.env-DEV</id>
 			<properties>
 				<js.minimized>false</js.minimized>
 				<ispyb.env>DEV</ispyb.env>
@@ -410,7 +410,7 @@
 		<!-- profiles to separate site dependent properties : the properties are 
 			stored in pom.xml of ispyb-ejb module -->
 		<profile>
-			<id>ESRF</id>
+			<id>ispyb.site-ESRF</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
@@ -424,11 +424,11 @@
 		</profile>
 
 		<profile>
-			<id>EMBL</id>
+			<id>ispyb.site-EMBL</id>
 		</profile>
 
 		<profile>
-			<id>SOLEIL</id>
+			<id>ispyb.site-SOLEIL</id>
 
 			<build>
 				<plugins>
@@ -474,7 +474,7 @@
 		</profile>
 
 		<profile>
-			<id>MAXIV</id>
+			<id>ispyb.site-MAXIV</id>
 		</profile>
 
 	</profiles>

--- a/ispyb-ui/pom.xml
+++ b/ispyb-ui/pom.xml
@@ -392,7 +392,6 @@
 					<name>ispyb.env</name>
 					<value>production</value>
 				</property>
-				<activeByDefault>true</activeByDefault>
 			</activation>
 
 			<properties>

--- a/ispyb-ui/pom.xml
+++ b/ispyb-ui/pom.xml
@@ -381,8 +381,7 @@
 		</plugins>
 	</build>
 
-	<!-- profiles to separate development to production properties -->
-	<!-- the development properties have to be set according to your own development environment -->
+	<!-- profiles to separate environment properties -->
 	<profiles>
 	
 		<profile>
@@ -431,16 +430,6 @@
 			</properties>
 			
 
-		</profile>
-
-		<profile>
-			<id>ispyb.site-EMBL</id>
-			<activation>
-				<property>
-					<name>ispyb.site</name>
-					<value>EMBL</value>
-				</property>
-			</activation>
 		</profile>
 
 		<profile>
@@ -494,17 +483,6 @@
 
 			</properties>
 		</profile>
-
-		<profile>
-			<id>ispyb.site-MAXIV</id>
-			<activation>
-				<property>
-					<name>ispyb.site</name>
-					<value>MAXIV</value>
-				</property>
-			</activation>
-		</profile>
-
 	</profiles>
 
 </project>

--- a/ispyb-ui/src/main/webapp/tiles/bodies/biosaxs/project/biosaxs_css_include.jsp
+++ b/ispyb-ui/src/main/webapp/tiles/bodies/biosaxs/project/biosaxs_css_include.jsp
@@ -29,7 +29,7 @@ Contributors : S. Delageniere, R. Leal, L. Launer, K. Levik, S. Veyrier, P. Bren
 // 				java.io.InputStream buildPropertiesInputStream = getServletContext().getResourceAsStream("/WEB-INF/classes/ISPyB_common.properties");
 // 				buildProperties.load(buildPropertiesInputStream);
 // 				if ( buildProperties.getProperty("ispyb.env") != null){
-// 					if ( buildProperties.getProperty("ispyb.env").toString().equals("DEV")){
+// 					if ( buildProperties.getProperty("ispyb.env").toString().equals("development")){
 // 						java.util.Properties devProperties = new java.util.Properties();
 // 						java.io.InputStream devInputStream = getServletContext().getResourceAsStream("/WEB-INF/classes/ISPyB_dev_ESRF.properties");
 // 						devProperties.load(devInputStream);

--- a/ispyb-ui/src/main/webapp/tiles/bodies/biosaxs/project/biosaxs_css_include.jsp
+++ b/ispyb-ui/src/main/webapp/tiles/bodies/biosaxs/project/biosaxs_css_include.jsp
@@ -28,8 +28,8 @@ Contributors : S. Delageniere, R. Leal, L. Launer, K. Levik, S. Veyrier, P. Bren
 // 				java.util.Properties buildProperties = new java.util.Properties();
 // 				java.io.InputStream buildPropertiesInputStream = getServletContext().getResourceAsStream("/WEB-INF/classes/ISPyB_common.properties");
 // 				buildProperties.load(buildPropertiesInputStream);
-// 				if ( buildProperties.getProperty("ispyb.deployment.mode") != null){
-// 					if ( buildProperties.getProperty("ispyb.deployment.mode").toString().equals("DEV")){
+// 				if ( buildProperties.getProperty("ispyb.env") != null){
+// 					if ( buildProperties.getProperty("ispyb.env").toString().equals("DEV")){
 // 						java.util.Properties devProperties = new java.util.Properties();
 // 						java.io.InputStream devInputStream = getServletContext().getResourceAsStream("/WEB-INF/classes/ISPyB_dev_ESRF.properties");
 // 						devProperties.load(devInputStream);

--- a/ispyb-ui/src/main/webapp/tiles/bodies/common/logon/logon.jsp
+++ b/ispyb-ui/src/main/webapp/tiles/bodies/common/logon/logon.jsp
@@ -123,7 +123,11 @@ Contributors : S. Delageniere, R. Leal, L. Launer, K. Levik, S. Veyrier, P. Bren
   		<layout:panel key="Messages" align="center" styleClass="PANEL_LOGON" width="270px">
 	  		<layout:grid cols="1" styleClass="SEARCH_GRID"  borderSpacing="5">	
 	      		<layout:column>
-  					<%=adminVar.getValue("infoMessage")%>
+  					<%
+  						String infoMessage = adminVar.getValue(Constants.MESSAGE_INFO);
+  						if (infoMessage.equals("unknown var")) infoMessage = "";
+  					%>
+  					<%=infoMessage%>
   				</layout:column>
   			</layout:grid> 
 		 </layout:panel>

--- a/ispyb-ui/src/main/webapp/tiles/layouts/unloggedLayout.jsp
+++ b/ispyb-ui/src/main/webapp/tiles/layouts/unloggedLayout.jsp
@@ -201,5 +201,28 @@ Contributors : S. Delageniere, R. Leal, L. Launer, K. Levik, S. Veyrier, P. Bren
 	</TABLE>
 </c:if>
 
+<c:if test="${SITE_ATTRIBUTE eq 'GENERIC'}">
+	<!-- ****************** begin Body of the page: menu left + content + footer *********************** -->
+	<TABLE cellSpacing="0" cellPadding="0" width="100%" border="0">
+	  <TBODY>
+	    <TR>
+	      <!-- MENU LEFT (navigation + additional links) -->
+	      <TD class=navbartable vAlign=top width=150>
+	      <!-- MENU LEFT: navigation -->
+	        <tiles:insert attribute="left_menu" />
+	      <!-- end of Nav -->
+	      </TD>
+	      <TD><IMG height=1 alt="" src="<%=request.getContextPath()%>/images/pixel_clear.gif" width=10 border=0></TD>
+	      <TD class=margintop vAlign=top>
+	        <!-- ******** BEGIN CONTENT AREA ******** -->
+	        <tiles:insert attribute="body" />
+	        <!-- ******** END CONTENT AREA ******** -->
+	      </TD>
+	    </TR>
+	    <!-- Footer -->
+	  </TBODY>
+	</TABLE>
+</c:if>
+
 </BODY>
 </HTML>

--- a/ispyb-ws/src/main/java/ispyb/ws/rest/security/AuthenticationRestWebService.java
+++ b/ispyb-ws/src/main/java/ispyb/ws/rest/security/AuthenticationRestWebService.java
@@ -8,6 +8,7 @@ import ispyb.ws.rest.security.login.EMBLLoginModule;
 import ispyb.ws.rest.security.login.ESRFLoginModule;
 import ispyb.ws.rest.security.login.SOLEILLLoginModule;
 import ispyb.ws.rest.security.login.MAXIVLoginModule;
+import ispyb.ws.rest.security.login.PropertyLoginModule;
 
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
@@ -91,6 +92,9 @@ public class AuthenticationRestWebService extends RestWebService {
 						break;
 					case "MAXIV":
 						roles = MAXIVLoginModule.authenticate(login, password);
+						break;
+					case "GENERIC":
+						roles = PropertyLoginModule.authenticate(login, password);
 						break;
 					default:
 						throw new Exception("Site is not defined");

--- a/ispyb-ws/src/main/java/ispyb/ws/rest/security/login/PropertyLoginModule.java
+++ b/ispyb-ws/src/main/java/ispyb/ws/rest/security/login/PropertyLoginModule.java
@@ -1,0 +1,193 @@
+package ispyb.ws.rest.security.login;
+
+import ispyb.common.util.Constants;
+import ispyb.server.common.util.ISPyBException;
+import ispyb.server.common.util.ISPyBRuntimeException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * A login module whose credentials store is an ISPyB property.
+ * <p>
+ * The credentials store for this module is the value of the
+ * {@code ispyb.ws.rest.auth.property.credentials} ISPyB property. The value is
+ * a semicolon-separated list of credentials where a credential has the form:
+ * <p>
+ * <pre>
+ * {@code <username>,<password>[,<role-list>]}</pre>
+ * <p>
+ * and {@code <role-list>} has the form:
+ * <p>
+ * <pre>
+ * {@code <role>[,...]}</pre>
+ * <p>
+ * Whitespace is taken literally, not skipped. It is illegal for a
+ * {@code <username>} or {@code <role>} (if specified) to be empty. Note that
+ * {@code <password>} is plaintext, not ciphertext. The {@code <role-list>} is
+ * optional. And because commas and semicolons are used as delimiters, these
+ * two characters are illegal in {@code <username>}, {@code <password>}, and
+ * {@code <role>}.
+ * <p>
+ * Here's an example credentials list of two users:
+ * <p>
+ * <pre>
+ * {@code alice,dragon,User,Manager;bob,batman,User}</pre>
+ * <p>
+ * The first user is "alice" with password "dragon" and the roles "User" and
+ * "Manager". The second is the user "bob" with password "batman" and the role
+ * "User".
+ * <p>
+ * NOTE: Because the passwords are stored in the property as plaintext, this
+ * module is not suitable for production use, but it can be useful for
+ * development and testing since it's easy to define users.
+ *
+ */
+public class PropertyLoginModule {
+  private static final Map<String, Credential> CREDENTIALS = readCredentials();
+  private static final Credential NONEXISTENT_USER_CREDENTIAL = createNonexistentUserCredential();
+
+  /**
+   * Returns the roles of the user if authentication succeeds.
+   *
+   * @param username the username of the user to authenticate
+   * @param password the password of the user to authenticate
+   *
+   * @return the roles of the authenticated user
+   *
+   * @throws ISPyBException if the user could not be authenticated
+   */
+  public static List<String> authenticate(String username, String password) throws ISPyBException {
+    Credential existingCredential = CREDENTIALS.get(username);
+    boolean userExists = (existingCredential != null);
+    Credential c = userExists ? existingCredential : NONEXISTENT_USER_CREDENTIAL;
+    boolean passwordEquals = constantTimeEquals(c.getPasswordHash(), hash(password));
+    if (userExists && passwordEquals) return c.getRoles();
+    throw new ISPyBException("Unauthorized");
+  }
+
+  private static final Map<String, Credential> readCredentials() throws ISPyBRuntimeException {
+    try {
+      return Collections
+          .unmodifiableMap(
+              parseCredentials(Constants.getProperty("ispyb.ws.rest.auth.property.credentials")));
+    } catch (ParseException e) {
+      ISPyBRuntimeException ex = new ISPyBRuntimeException("Invalid credentials store");
+      ex.initCause(e);
+      throw ex;
+    }
+  }
+
+  private static final Map<String, Credential> parseCredentials(String credentialsList)
+      throws ParseException {
+    final Pattern semicolonPat = Pattern.compile(";");
+    final Pattern commaPat = Pattern.compile(",");
+    Map<String, Credential> result = new HashMap<>();
+    if (credentialsList == null) return result;
+    if (credentialsList.isEmpty()) return result;
+    int offset = 0;
+    String[] credentials = semicolonPat.split(credentialsList, -1);
+    for (int credentialIndex = 0; credentialIndex < credentials.length; credentialIndex++) {
+      if (credentialIndex > 0) offset += ";".length();
+      String credential = credentials[credentialIndex];
+      String[] parts = commaPat.split(credential, -1);
+      if (parts.length < 2) {
+        throw new ParseException("Credential \"" + credential + "\" not list of 2 or more", offset);
+      }
+      String username = parts[0];
+      if (username.isEmpty()) {
+        throw new ParseException("Username is empty", offset);
+      }
+      offset += username.length() + ",".length();
+      String password = parts[1];
+      offset += password.length();
+      List<String> roles = Arrays.asList(parts).subList(2, parts.length);
+      if (!roles.isEmpty()) offset += ",".length();
+      for (ListIterator<String> rolesIterator = roles.listIterator(); rolesIterator.hasNext();) {
+        if (rolesIterator.hasPrevious()) offset += ",".length();
+        String role = rolesIterator.next();
+        if (role.isEmpty()) {
+          throw new ParseException("Role is empty", offset);
+        }
+        offset += role.length();
+      }
+      result.put(username, new Credential(username, hash(password), roles));
+    }
+    return result;
+  }
+
+  /*
+   * Hashes the plaintext password into a fixed-size byte array.  The
+   * algorithm is SHA-256, a one-way hash function.  The only requirement
+   * for the one-way hash function used here is that it doesn't have a high
+   * probability of collision such that many different passwords would all
+   * have the same hash value thus making a brute-force attack easier.  A
+   * proper key derivation function is not used here because the passwords for
+   * this login module are stored in plaintext, so if they're ever obtained,
+   * it's game over anyway.
+   */
+  private static final byte[] hash(String password) {
+    MessageDigest md;
+    try {
+      md = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      throw new AssertionError(e);
+    }
+    md.update(password.getBytes(StandardCharsets.UTF_8));
+    return md.digest();
+  }
+
+  private static final boolean constantTimeEquals(byte[] a, byte[] b) {
+    if (a.length != b.length) throw new IllegalArgumentException("a.length != b.length");
+    byte result = 0;
+    for (int i = 0; i < a.length; i++) {
+      result |= a[i] ^ b[i];
+    }
+    return result == 0;
+  }
+
+  private static final Credential createNonexistentUserCredential() {
+    return new Credential("", hash(""), Collections.<String>emptyList());
+  }
+
+  private static final class Credential {
+    private final String username;
+    private final byte[] passwordHash;
+    private final List<String> roles;
+
+    /**
+     * The caller must not modify {@code passwordHash} nor {@code roles} after
+     * calling this constructor.
+     */
+    public Credential(String username, byte[] passwordHash, List<String> roles) {
+      this.username = username;
+      this.passwordHash = passwordHash;
+      this.roles = Collections.unmodifiableList(roles);
+    }
+
+    @SuppressWarnings("unused")
+    public String getUsername() {
+      return username;
+    }
+
+    /**
+     * The caller must not modify the returned byte array.
+     */
+    public byte[] getPasswordHash() {
+      return passwordHash;
+    }
+
+    public List<String> getRoles() {
+      return roles;
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,26 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0-M2</version>
+				<executions>
+					<execution>
+						<id>enforce-maven</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>[3.3.1,)</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,80 @@
 
 
 	<profiles>
+		<!-- Environment profiles -->
+		<profile>
+			<id>ispyb.env-production</id>
+			<activation>
+				<property>
+					<name>ispyb.env</name>
+					<value>production</value>
+				</property>
+			</activation>
+		</profile>
+		<profile>
+			<id>ispyb.env-development</id>
+			<activation>
+				<property>
+					<name>ispyb.env</name>
+					<value>development</value>
+				</property>
+			</activation>
+		</profile>
+		<profile>
+			<id>ispyb.env-test</id>
+			<activation>
+				<property>
+					<name>ispyb.env</name>
+					<value>test</value>
+				</property>
+			</activation>
+		</profile>
+		<!-- Site profiles -->
+		<profile>
+			<id>ispyb.site-ESRF</id>
+			<activation>
+				<property>
+					<name>ispyb.site</name>
+					<value>ESRF</value>
+				</property>
+			</activation>
+		</profile>
+		<profile>
+			<id>ispyb.site-EMBL</id>
+			<activation>
+				<property>
+					<name>ispyb.site</name>
+					<value>EMBL</value>
+				</property>
+			</activation>
+		</profile>
+		<profile>
+			<id>ispyb.site-SOLEIL</id>
+			<activation>
+				<property>
+					<name>ispyb.site</name>
+					<value>SOLEIL</value>
+				</property>
+			</activation>
+		</profile>
+		<profile>
+			<id>ispyb.site-MAXIV</id>
+			<activation>
+				<property>
+					<name>ispyb.site</name>
+					<value>MAXIV</value>
+				</property>
+			</activation>
+		</profile>
+		<profile>
+			<id>ispyb.site-GENERIC</id>
+			<activation>
+				<property>
+					<name>ispyb.site</name>
+					<value>GENERIC</value>
+				</property>
+			</activation>
+		</profile>
 	    <profile>
      <!-- When built in OpenShift the 'openshift' profile will be used when invoking mvn. -->
      <!-- Use this profile for any OpenShift specific customization your app will need. -->


### PR DESCRIPTION
This patch series makes it easier to build and run ISPyB out of the box.  When I first went to try out ISPyB, it was very difficult because I couldn't just build and run it; it required a lot of modifications to ISPyB files just to get to the place of being able to build and run it, and it required an LDAP server for authentication of RESTful web services.  This patch series tries to improve that situation.

* Makes it so that there is a `GENERIC` site which can be used out of the box.
* Makes it so that the credentials store for the RESTful web services authentication for the `GENERIC` site can be specified in an ISPyB property instead of requiring an LDAP server.
* Renames "deployment mode" to "environment" and makes there be three environments: `production`, `development`, and `test`.  If you have any references to these (e.g., in a script for a Maven command line invocation or in `~/.m2/settings.xml`), they will need to be updated.
* Makes it so that there is a default ISPyB environment (`development`) and site (`GENERIC`) when building ISPyB from the command line (e.g., `mvn clean install`).  Note that `ESRF` is no longer the default site.
* Makes it so that the ISPyB environment and site can vary independently without having to specify the other.  This is done by activating those profiles with system properties: `ispyb.env` and `ispyb.site`, respectively.  Prior to this change, the Maven build system relied on default profile activation, but this was very fragile because once a profile is activated explicitly, a profile activated by default is no longer activated.  So, once you explicitly activated a profile, you had to know and specify the full set of profiles that needed to be activated.  Now, you can set just the ISPyB environment or site without worrying about the other (or potentially others in the future).
* Requires Maven 3.3.1 (released on 2015-03-18) or later.  Maven 3.3.1 is the version that introduced support for `.mvn/{jvm,maven}.config` in a project.  This feature is used to provide the default ISPyB environment and site.
* The ISPyB environment and site can be set on a per-user basis by setting the `ispyb.env` or `ispyb.site` system properties, respectively, with the `-D` option in the `MAVEN_OPTS` environment variable.  The ISPyB environment and site can be set on the command line by setting those same system properties with the `-D` option.
* The SOLEIL site profile no longer sets the environment to `production`.  That was an unusual place to set that because it meant that you could never build for the `SOLEIL` site for any environment other than `production`.  To get the same behavior as before, the SOLEIL site system administrator should arrange for the `ispyb.env` system property to be set to `production` when building ISPyB.