### PR TITLE
New protein cols: containmentLevel, hazardGroup, description

### DIFF
--- a/ispyb-ejb/db/scripts/ahead/2020_09_09_Protein_new_cols.sql
+++ b/ispyb-ejb/db/scripts/ahead/2020_09_09_Protein_new_cols.sql
@@ -1,0 +1,11 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2020_09_09_Protein_new_cols.sql', 'ONGOING');
+
+ALTER TABLE Protein
+    ADD `description` TEXT NULL DEFAULT NULL 
+        COMMENT 'A description/summary using words and sentences' AFTER `acronym`,
+    ADD `hazardGroup` tinyint unsigned DEFAULT 1 NOT NULL 
+        COMMENT 'A.k.a. risk group' AFTER `description`,
+    ADD `containmentLevel` tinyint unsigned DEFAULT 1 NOT NULL
+        COMMENT 'A.k.a. biosafety level, which indicates the level of containment required' AFTER `hazardGroup`;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2020_09_09_Protein_new_cols.sql';


### PR DESCRIPTION
New columns for the Protein table:

- containmentLevel: a TINYINT to indicate the CL level. We're using TINYINT instead of enum('CL1, ...) because not all countries use these names, but they do use the same numbers 1, 2, 3 etc.
- hazardGroup: a TINYINT to indicate the hazard group a.k.a. risk group in some countries.
- description: A TEXT to hold a description/summary using words and sentences.

There were no objections to this at the ISPyB developers meeting today.