### PR TITLE
Add a name col to BLSampleGroup

### DIFF
--- a/ispyb-ejb/db/scripts/ahead/2020_09_09_BLSampleGroup_name.sql
+++ b/ispyb-ejb/db/scripts/ahead/2020_09_09_BLSampleGroup_name.sql
@@ -1,0 +1,5 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2020_09_09_BLSampleGroup_name.sql', 'ONGOING');
+
+ALTER TABLE BLSampleGroup ADD name varchar(100) COMMENT 'Human-readable name';
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2020_09_09_BLSampleGroup_name.sql';


### PR DESCRIPTION
Add a name column to the BLSampleGroup table.

The BLSampleGroup table is currently probably only used at Diamond. It's useful for grouping samples, so you can say that these samples belong together.

There were no objections to this at the ISPyB developers meeting today.