### PR TITLE
Add a userPath col to the DiffractionPlan table

### DIFF
--- a/ispyb-ejb/db/scripts/ahead/2020_09_09_DiffractionPlan_userPath.sql
+++ b/ispyb-ejb/db/scripts/ahead/2020_09_09_DiffractionPlan_userPath.sql
@@ -1,0 +1,7 @@
+INSERT IGNORE INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2020_09_09_DiffractionPlan_userPath.sql', 'ONGOING');
+
+ALTER TABLE DiffractionPlan 
+  ADD userPath varchar(100) 
+    COMMENT 'User-specified relative "root" path inside the session directory to be used for holding collected data';
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2020_09_09_DiffractionPlan_userPath.sql';


### PR DESCRIPTION
Add a userPath column to the DiffractionPlan table

This is a user-specified relative "root" path inside the session directory to be used for holding the collected data.

There were no objections to this at the ISPyB developers meeting today.