### PR TITLE
Added getStructuresAcronymByDataCollectionId

### DIFF
--- a/ispyb-ejb/src/main/java/ispyb/server/biosaxs/services/core/structure/Structure3Service.java
+++ b/ispyb-ejb/src/main/java/ispyb/server/biosaxs/services/core/structure/Structure3Service.java
@@ -32,6 +32,9 @@ import javax.ejb.Remote;
 public interface Structure3Service {
 	
 	public abstract List<Structure3VO> getStructuresByDataCollectionId(Integer dataCollectionId) throws Exception;
+
+	public abstract List<Structure3VO> getProteinStructuresByDataCollectionId(Integer dataCollectionId) throws Exception;
+	
 	
 	public abstract List<Structure3VO> getStructuresByProposalId(Integer proposalId) throws Exception;
 

--- a/ispyb-ejb/src/main/java/ispyb/server/biosaxs/services/core/structure/Structure3Service.java
+++ b/ispyb-ejb/src/main/java/ispyb/server/biosaxs/services/core/structure/Structure3Service.java
@@ -35,9 +35,7 @@ public interface Structure3Service {
 
 	public abstract List<Structure3VO> getProteinStructuresByDataCollectionId(Integer dataCollectionId) throws Exception;
 	
-	
 	public abstract List<Structure3VO> getStructuresByProposalId(Integer proposalId) throws Exception;
-
 	
 	public List<Structure3VO> getStructuresByCrystalId(Integer crystalId) throws Exception;
 

--- a/ispyb-ejb/src/main/java/ispyb/server/biosaxs/services/core/structure/Structure3ServiceBean.java
+++ b/ispyb-ejb/src/main/java/ispyb/server/biosaxs/services/core/structure/Structure3ServiceBean.java
@@ -20,13 +20,16 @@
 package ispyb.server.biosaxs.services.core.structure;
 
 import ispyb.server.biosaxs.vos.assembly.Structure3VO;
+import ispyb.server.biosaxs.vos.datacollection.SaxsDataCollection3VO;
 import ispyb.server.mx.services.sample.BLSample3ServiceLocal;
 import ispyb.server.mx.vos.collections.DataCollection3VO;
 import ispyb.server.mx.vos.collections.DataCollectionGroup3VO;
 import ispyb.server.mx.vos.collections.Session3VO;
 import ispyb.server.mx.vos.sample.BLSample3VO;
 import ispyb.server.mx.vos.sample.Crystal3VO;
+import ispyb.server.mx.vos.sample.Protein3VO;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.ejb.EJB;
@@ -34,6 +37,7 @@ import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
 
 @Stateless
 public class Structure3ServiceBean implements Structure3Service, Structure3ServiceLocal {
@@ -72,8 +76,7 @@ public class Structure3ServiceBean implements Structure3Service, Structure3Servi
 		return (List<Structure3VO>) EJBQuery.getResultList();	
 	}
 	
-	@Override
-	public List<Structure3VO> getStructuresByDataCollectionId(Integer dataCollectionId) throws Exception {
+	private Crystal3VO getCrystalByDataCollectionId(Integer dataCollectionId) throws Exception {
 		DataCollection3VO dataCollection = entityManager.find(DataCollection3VO.class, dataCollectionId);
 		if (dataCollection != null){
 			DataCollectionGroup3VO dataCollectionGroup = entityManager.find(DataCollectionGroup3VO.class, dataCollection.getDataCollectionGroupVOId());
@@ -82,10 +85,9 @@ public class Structure3ServiceBean implements Structure3Service, Structure3Servi
 				if (blSample != null){
 					Crystal3VO crystal = entityManager.find(Crystal3VO.class, blSample.getCrystalVOId());
 					if (crystal != null){
-						return this.getStructuresByCrystalId(crystal.getCrystalId());
+						return crystal;
 					}
-				}
-				
+				}				
 			}
 		}
 		else{
@@ -93,6 +95,48 @@ public class Structure3ServiceBean implements Structure3Service, Structure3Servi
 		}
 		return null;
 	}
+
+	@Override
+	public List<Structure3VO> getStructuresByDataCollectionId(Integer dataCollectionId) throws Exception {
+		Crystal3VO crystal = this.getCrystalByDataCollectionId(dataCollectionId);
+		if (crystal != null){
+			return this.getStructuresByCrystalId(crystal.getCrystalId());
+		}				
+		throw new Exception("Not crystal found with dataCollectionId=" + dataCollectionId);
+	}
+
+	private List<Crystal3VO> getCrystalListByProteinId(Integer proteinId){
+		Protein3VO protein = entityManager.find(Protein3VO.class, proteinId);
+		StringBuilder ejbQLQuery = new StringBuilder();
+		ejbQLQuery.append("SELECT DISTINCT(crystal) FROM Crystal3VO  crystal ");
+		ejbQLQuery.append(" LEFT JOIN FETCH crystal.proteinVO protein ");
+		ejbQLQuery.append(" WHERE protein.proteinId = :proteinId");
+		TypedQuery<Crystal3VO> query = entityManager.createQuery(ejbQLQuery.toString(), Crystal3VO.class).setParameter("proteinId", protein.getProteinId());
+		return query.getResultList();
+	} 
+
+	@Override
+	public List<Structure3VO> getProteinStructuresByDataCollectionId(Integer dataCollectionId) throws Exception {
+		List<Structure3VO> structures = new ArrayList<Structure3VO>();
+
+		Crystal3VO crystal = this.getCrystalByDataCollectionId(dataCollectionId);
+		if (crystal != null){
+			Protein3VO protein = entityManager.find(Protein3VO.class, crystal.getProteinVOId());
+			/* Get all crystals by protein */
+			if (protein != null){
+				List<Crystal3VO> crystals = this.getCrystalListByProteinId(protein.getProteinId());
+				for (Crystal3VO crystal3vo : crystals) {
+					structures.addAll(this.getStructuresByCrystalId(crystal3vo.getCrystalId()));
+				}
+			}
+		}				
+		else{
+			throw new Exception("Not crystal found with dataCollectionId=" + dataCollectionId);
+		}
+		return structures;
+		
+	}
+
 	
 	@Override
 	public List<Structure3VO> getLigandsByDataCollectionId(Integer dataCollectionId) throws Exception {

--- a/ispyb-ejb/src/main/java/ispyb/server/biosaxs/services/core/structure/Structure3ServiceBean.java
+++ b/ispyb-ejb/src/main/java/ispyb/server/biosaxs/services/core/structure/Structure3ServiceBean.java
@@ -21,6 +21,7 @@ package ispyb.server.biosaxs.services.core.structure;
 
 import ispyb.server.biosaxs.vos.assembly.Structure3VO;
 import ispyb.server.biosaxs.vos.datacollection.SaxsDataCollection3VO;
+import ispyb.server.mx.services.sample.BLSample3ServiceBean;
 import ispyb.server.mx.services.sample.BLSample3ServiceLocal;
 import ispyb.server.mx.vos.collections.DataCollection3VO;
 import ispyb.server.mx.vos.collections.DataCollectionGroup3VO;
@@ -39,8 +40,11 @@ import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 
+import org.apache.log4j.Logger;
+
 @Stateless
 public class Structure3ServiceBean implements Structure3Service, Structure3ServiceLocal {
+	private final static Logger LOG = Logger.getLogger(Structure3ServiceBean.class);
 
 	@PersistenceContext(unitName = "ispyb_db")
 	private EntityManager entityManager;
@@ -70,7 +74,7 @@ public class Structure3ServiceBean implements Structure3Service, Structure3Servi
 	
 	@SuppressWarnings("unchecked")
 	@Override
-	public List<Structure3VO> getStructuresByProposalId(Integer proposalId) throws Exception {
+	public List<Structure3VO> getStructuresByProposalId(Integer proposalId) throws Exception {		
 		String query = "SELECT structure3VO FROM Structure3VO structure3VO where structure3VO.proposalId = :proposalId" ;
 		Query EJBQuery = this.entityManager.createQuery(query).setParameter("proposalId", proposalId);
 		return (List<Structure3VO>) EJBQuery.getResultList();	
@@ -117,6 +121,7 @@ public class Structure3ServiceBean implements Structure3Service, Structure3Servi
 
 	@Override
 	public List<Structure3VO> getProteinStructuresByDataCollectionId(Integer dataCollectionId) throws Exception {
+		LOG.info("getProteinStructuresByDataCollectionId. dataCollectionId=" + dataCollectionId);
 		List<Structure3VO> structures = new ArrayList<Structure3VO>();
 
 		Crystal3VO crystal = this.getCrystalByDataCollectionId(dataCollectionId);

--- a/ispyb-ws/src/main/java/ispyb/ws/soap/mx/ToolsForBLSampleWebService.java
+++ b/ispyb-ws/src/main/java/ispyb/ws/soap/mx/ToolsForBLSampleWebService.java
@@ -454,6 +454,7 @@ public class ToolsForBLSampleWebService {
 			return convertStructuresToCSV(structures);
 		} catch (Exception e) {
 			e.printStackTrace();
+			LOG.error(e.getMessage());
 		}
 		return null;
 	}
@@ -477,6 +478,7 @@ public class ToolsForBLSampleWebService {
 			return convertStructuresToCSV(structures);
 		} catch (Exception e) {
 			e.printStackTrace();
+			LOG.error(e.getMessage());
 		}
 		return null;
 	}

--- a/ispyb-ws/src/main/java/ispyb/ws/soap/mx/ToolsForBLSampleWebService.java
+++ b/ispyb-ws/src/main/java/ispyb/ws/soap/mx/ToolsForBLSampleWebService.java
@@ -473,6 +473,7 @@ public class ToolsForBLSampleWebService {
 		try {
 			Structure3Service structure3service = (Structure3Service) ejb3ServiceLocator.getLocalService(Structure3Service.class);
 			List<Structure3VO> structures = structure3service.getProteinStructuresByDataCollectionId(dataCollectionId);
+			LOG.debug("getProteinStructuresByDataCollectionId. dataCollectionId=" + dataCollectionId + " structures=" + structures.size());
 			return convertStructuresToCSV(structures);
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/ispyb-ws/src/main/java/ispyb/ws/soap/mx/ToolsForBLSampleWebService.java
+++ b/ispyb-ws/src/main/java/ispyb/ws/soap/mx/ToolsForBLSampleWebService.java
@@ -457,6 +457,29 @@ public class ToolsForBLSampleWebService {
 		}
 		return null;
 	}
+
+	/**
+	 * returns the pdb filePath for all crystals linked to a protein associated to a given dataCollectionId
+	 * 
+	 * @param code
+	 * @param number
+	 * @return
+	 * @throws Exception
+	 */
+	@WebMethod
+	@WebResult(name = "structures")
+	public String getProteinStructuresByDataCollectionId(
+	@WebParam(name = "dataCollectionId")Integer dataCollectionId) throws Exception {
+		try {
+			Structure3Service structure3service = (Structure3Service) ejb3ServiceLocator.getLocalService(Structure3Service.class);
+			List<Structure3VO> structures = structure3service.getProteinStructuresByDataCollectionId(dataCollectionId);
+			return convertStructuresToCSV(structures);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
 	
 	private String convertStructuresToCSV(List<Structure3VO> structures) {
 


### PR DESCRIPTION
A new webmethod has been added to retrieve all the structures linked to a Protein that is associated with a datacollection.

Name of the method `getProteinStructuresByDataCollectionId`
